### PR TITLE
Disable selector input once puzzle is solved

### DIFF
--- a/public/game/view-models/app-viewmodel.coffee
+++ b/public/game/view-models/app-viewmodel.coffee
@@ -1,6 +1,10 @@
 warp = require 'nexus-warp'
 {nx} = require 'nexus'
 
+Cascade = require 'cssqd-shared/nx/cascade'
+RoundPhase = require 'cssqd-shared/models/round-phase'
+SelectorMatchResult = require 'cssqd-shared/models/selector-match-result'
+
 dateTimeFormats = (require 'common/utils/date-time-utils').formats
 
 Round = require '../models/round'
@@ -62,6 +66,9 @@ class AppViewModel
 		@userPanelViewModel = new UserPanelViewModel @user_data
 		@roundTimerViewModel = new TimespanViewModel @countdown, dateTimeFormats['m:ss']
 		@countdownViewModel = new TimespanViewModel @countdown, dateTimeFormats['s']
+
+		@selector_input_disabled = Cascade @round_phase, @match, (round_phase, match) ->
+			round_phase is RoundPhase.IN_PROGRESS and match.result is SelectorMatchResult.POSITIVE
 
 		#Keep session ID set as the last operation as it triggers the data flow
 		@game_session_id.value = sessionId

--- a/public/game/view-models/app-viewmodel.coffee
+++ b/public/game/view-models/app-viewmodel.coffee
@@ -70,6 +70,9 @@ class AppViewModel
 		@selector_input_disabled = Cascade @round_phase, @match, (round_phase, match) ->
 			round_phase is RoundPhase.IN_PROGRESS and match.result is SelectorMatchResult.POSITIVE
 
+		@selector_input_disabled['<-'] @round_phase, (round_phase) ->
+			round_phase isnt RoundPhase.IN_PROGRESS
+
 		#Keep session ID set as the last operation as it triggers the data flow
 		@game_session_id.value = sessionId
 

--- a/public/game/views/game-view.coffee
+++ b/public/game/views/game-view.coffee
@@ -39,8 +39,8 @@ GameView = (context) ->
 							nxt.Event 'input', context.selector, (event) -> event.target.value
 							nxt.Attr 'placeholder', 'Enter your selector here...'
 							nxt.Focus yes
-							# nxt.Binding context.match, (match) ->
-							# 	nxt.Attr 'disabled' if match?.result is SelectorMatchResult.POSITIVE
+							nxt.Binding context.selector_input_disabled, (disabled) ->
+								nxt.Attr 'disabled' if disabled
 
 				TimespanView context.roundTimerViewModel
 

--- a/shared/nx/cascade.coffee
+++ b/shared/nx/cascade.coffee
@@ -1,0 +1,18 @@
+{nx} = require 'nexus'
+
+module.exports = ->
+	[cells..., conversion] = arguments
+	cascade = new nx.Cell
+	acc = new nx.Cell
+		value: []
+		'->': [
+			((values) ->
+				if values.length is cells.length then cascade else []),
+				(values) -> conversion values...
+			]
+
+	cells.forEach (cell, index) ->
+		cell['->'] acc, (value) ->
+			acc.value.splice(0, index).concat value
+
+	cascade


### PR DESCRIPTION
`Cascade` is a new cell combinator (experimental):

```coffeescript
Cascade cell1, cell2, ... , cellN, conversion
```
will wait for a full sequence of value changes in specified cells left to right (all cells have to yield values in this particular order).

```coffeescript
Cascade @round_phase, @match
```
triggers only when `round_phase` has a new value _and_ `match` has a new value. That is, for every `round_phase` change there has to be a change from `match`. :cat: 