### PR TITLE
Use master branch of nexus-warp

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "nexus": "git://github.com/DaQuirm/nexus#master",
     "normalize.css": "~3.0.3",
-    "nexus-warp": "git://github.com/DaQuirm/nexus-warp#cssconf-budapest",
+    "nexus-warp": "git://github.com/DaQuirm/nexus-warp#master",
     "cssqd-shared": "./shared",
     "backspace-block": "~1.0.1"
   }


### PR DESCRIPTION
I think we forgot to switch this branch actually 😅 
Anyway, `nexus-warp` now uses [µws](https://github.com/uWebSockets/uWebSockets) as a WebSocket transport which is supposed to be more performant: [43e18341](https://github.com/DaQuirm/nexus-warp/commit/43e18341176ee0ed2577523d50df80e59f2716ad).

@R1ZZU @kirilknysh 